### PR TITLE
Fixes Symbol#to_proc

### DIFF
--- a/lib/ole/support.rb
+++ b/lib/ole/support.rb
@@ -36,9 +36,9 @@ end
 
 class Symbol # :nodoc:
 	unless Symbol.instance_methods.include?(:to_proc)
-		def to_proc
-			proc { |a| a.send self }
-		end
+    def to_proc
+      Proc.new { |*args| args.shift.__send__(self, *args) }
+    end
 	end
 end
 

--- a/test/test_support.rb
+++ b/test/test_support.rb
@@ -44,6 +44,11 @@ class TestSupport < Test::Unit::TestCase
 		# note not [6, 7] - no overlaps
 		assert_equal [6], str.indexes('||')
 	end
+
+  def test_symbol
+    array = (1..10).to_a
+    assert_equal 55, array.inject(&:+)
+  end
 end
 
 class TestIOMode < Test::Unit::TestCase


### PR DESCRIPTION
The Symbol#to_proc method overrides the similar method in Rails ActiveSupport core extensions. I imagine this has something to do with the gem load sequence. But anyway the current Symbol#to_proc in ruby-ole doesn't seem to perform 'as expected' (see the included test for a definition of 'as expected').
