### PR TITLE
RangesIO#write corrupts output if passed and UTF8 string

### DIFF
--- a/lib/ole/ranges_io.rb
+++ b/lib/ole/ranges_io.rb
@@ -195,6 +195,11 @@ class RangesIO
 	end
 
 	def write data
+		# duplicates object to avoid side effects for the caller, but do so only if
+		# encoding isn't already ASCII-8BIT (slight optimization)
+		unless data.encoding == Encoding::ASCII_8BIT
+			data = data.dup.force_encoding(Encoding::ASCII_8BIT)
+		end
 		return 0 if data.empty?
 		data_pos = 0
 		# if we don't have room, we can use the truncate hook to make more space.

--- a/test/test_storage.rb
+++ b/test/test_storage.rb
@@ -1,4 +1,5 @@
 #! /usr/bin/ruby
+# coding: utf-8
 
 $: << File.dirname(__FILE__) + '/../lib'
 #require 'rubygems'
@@ -214,6 +215,26 @@ class TestStorageWrite < Test::Unit::TestCase
 			dirent.to_s
 			assert_equal 1, dirent.type_id
 			assert_raises(ArgumentError) { Ole::Storage::Dirent.new ole, :type => :bogus }
+		end
+	end
+	
+	def test_write_utf8_string
+		tmp_file = "#{TEST_DIR}/encoding.tmp"
+		begin
+			Ole::Storage.open File.open(tmp_file, 'wb+') do |ole|
+				ole.file.open '1', 'w' do |writer|
+					writer.write("programação ")
+					writer.write("ruby")
+				end
+			end
+				
+			Ole::Storage.open File.open(tmp_file, 'rb') do |ole|
+				ole.file.open '1', 'r' do |reader|
+					assert_equal("programação ruby", reader.read.force_encoding('UTF-8'))
+				end
+			end
+		ensure
+			FileUtils.rm(tmp_file) if File.exist?(tmp_file)
 		end
 	end
 end


### PR DESCRIPTION
RangesIO#write has a bug which corrupts the output file if the encoding is UTF-8, due to differences between the string size as reported by String#length and the actual number of bytes written (as File#tell would report). This patch fixes de issue.
