### PR TITLE
Integer Unification for Ruby 2.4.0+

### DIFF
--- a/lib/ole/support.rb
+++ b/lib/ole/support.rb
@@ -198,7 +198,7 @@ module Ole
 		attr_reader :flags
 		def initialize flags
 			flags = self.class.parse_mode flags.to_str if flags.respond_to? :to_str
-			raise ArgumentError, "invalid flags - #{flags.inspect}" unless Fixnum === flags
+			raise ArgumentError, "invalid flags - #{flags.inspect}" unless Integer === flags
 			@flags = flags
 		end
 


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warning in Ruby 2.4.0-rc1.

`warning: constant ::Fixnum is deprecated`

Thanks.