### PR TITLE
fixed FrozenError error caused by frozen string literal

### DIFF
--- a/lib/ole/ranges_io.rb
+++ b/lib/ole/ranges_io.rb
@@ -156,7 +156,7 @@ class RangesIO
 
 	# read bytes from file, to a maximum of +limit+, or all available if unspecified.
 	def read limit=nil
-		data = ''
+		data = ''.dup
 		return data if eof?
 		limit ||= size
 		pos, len = @ranges[@active]


### PR DESCRIPTION
Hi,

I got following FrozenError when I used ruby-ole gem and `--enable-frozen-string-literal` option.
```
  FrozenError:
       can't modify frozen String, created at C:/Ruby/Ruby25-x64/lib/ruby/gems/2.5.0/gems/ruby-ole-1.2.12.1/lib/ole/ranges_io.rb:159
```
This PR is to fix the above error.
