### PR TITLE
Clean up unit test errors caused by frozen string literal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ rvm:
 
 matrix:
   include:
-    - rvm: 2.3.0
-      env: RUBYOPT=--enable-frozen-string-literal
-    - rvm: 2.4.0
-      env: RUBYOPT=--enable-frozen-string-literal
     - rvm: 2.5.0
       env: RUBYOPT=--enable-frozen-string-literal
     - rvm: 2.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+sudo:
+  false
+
+email:
+  false
+
+language:
+  ruby
+
+rvm:
+  - 1.8.7
+  - 1.9.2
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0
+  - 2.4.0
+  - 2.5.0
+  - 2.6.0
+
+matrix:
+  include:
+    - rvm: 2.3.0
+      env: RUBYOPT=--enable-frozen-string-literal
+    - rvm: 2.4.0
+      env: RUBYOPT=--enable-frozen-string-literal
+    - rvm: 2.5.0
+      env: RUBYOPT=--enable-frozen-string-literal
+    - rvm: 2.6.0
+      env: RUBYOPT=--enable-frozen-string-literal
+
+script:
+  - "rake test"
+

--- a/lib/ole/storage/base.rb
+++ b/lib/ole/storage/base.rb
@@ -315,7 +315,7 @@ module Ole # :nodoc:
 					io.binmode
 					repack_using_io io
 				end
-			when :mem;  StringIO.open('', &method(:repack_using_io))
+			when :mem;  StringIO.open(''.dup, &method(:repack_using_io))
 			else raise ArgumentError, "unknown temp backing #{temp.inspect}"
 			end
 		end

--- a/lib/ole/support.rb
+++ b/lib/ole/support.rb
@@ -135,7 +135,7 @@ module RecursivelyEnumerable # :nodoc:
 	#
 	# mostly a debugging aid. can specify a different block which will be called
 	# to provide the string form for each node.
-	def to_tree io='', &inspect
+	def to_tree io=''.dup, &inspect
 		inspect ||= :inspect.to_proc
 		io << "- #{inspect[self]}\n"
 		recurse = proc do |node, prefix|

--- a/test/test_filesystem.rb
+++ b/test/test_filesystem.rb
@@ -879,14 +879,14 @@ end
 
 class OleUnicodeTest < Test::Unit::TestCase
 	def setup
-		@io = StringIO.new ''
+		@io = StringIO.new ''.dup
 	end
 	
 	def test_unicode
 		# in ruby-1.8, encoding is assumed to be UTF-8 (and converted with iconv).
 		# in ruby-1.9, UTF-8 should work also, but probably shouldn't be using fixed
 		# TO_UTF16 iconv for other encodings.
-		resume = "R\xc3\xa9sum\xc3\xa9"
+		resume = "R\xc3\xa9sum\xc3\xa9".dup
 		resume.force_encoding Encoding::UTF_8 if resume.respond_to? :encoding
 		Ole::Storage.open @io do |ole|
 			ole.file.open(resume, 'w') { |f| f.write 'Skills: writing bad unit tests' }
@@ -908,7 +908,7 @@ class OleUnicodeTest < Test::Unit::TestCase
 	end
 
 	def test_write_utf8_string
-		programmer = "programa\xC3\xA7\xC3\xA3o "
+		programmer = "programa\xC3\xA7\xC3\xA3o ".dup
 		programmer.force_encoding Encoding::UTF_8 if programmer.respond_to? :encoding
 		Ole::Storage.open @io do |ole|
 			ole.file.open '1', 'w' do |writer|

--- a/test/test_storage.rb
+++ b/test/test_storage.rb
@@ -197,7 +197,7 @@ class TestStorageWrite < Test::Unit::TestCase
 	end
 
 	def test_create_from_scratch_hash
-		io = StringIO.new('')
+		io = StringIO.new(''.dup)
 		Ole::Storage.open(io) { }
 		assert_equal '6bb9d6c1cdf1656375e30991948d70c5fff63d57', sha1(io.string)
 		# more repack test, note invariance


### PR DESCRIPTION
I cleaned up unit test errors caused by frozen string literal.

Also I introduced CI regression test with Travis CI.
On the CI regression test, the gem is tested with following rubies:
  - 1.8.7
  - 1.9.2
  - 1.9.3
  - 2.0.0
  - 2.1.0
  - 2.2.0
  - 2.3.0
  - 2.4.0
  - 2.5.0
    - with --frozen-string-literal
  - 2.6.0
    - with --frozen-string-literal

Note:
Ruby 2.3 and 2.4 support frozen string literal but it seems that standard libraries for these version do not support the feature enough.
Therefore, frozen string literal is not enabled for CI regression test with Ruby 2.3 and 2.4.
