### PR TITLE
Remove deprecated `has_rdoc` attribute from gemspec

### DIFF
--- a/ruby-ole.gemspec
+++ b/ruby-ole.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
 	s.files += Dir.glob('bin/*')
 	s.test_files = Dir.glob('test/test_*.rb')
 
-	s.has_rdoc = true
 	s.extra_rdoc_files = ['README.rdoc', 'ChangeLog']
 	s.rdoc_options += [
 		'--main', 'README.rdoc',


### PR DESCRIPTION
The `has_rdoc=` attribute is deprecated and will be removed in RubyGems 4, deprecation warning was showing up when running the tests